### PR TITLE
feat: add basic Grid structs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ target
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# vscode
+**/.vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,6 +819,7 @@ name = "krustty"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bitflags 2.11.0",
  "env_logger",
  "pollster",
  "portable-pty",

--- a/krustty/Cargo.toml
+++ b/krustty/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 anyhow = "1.0.102"
+bitflags = "2.11.0"
 env_logger = "0.11.9"
 pollster = "0.4.0"
 portable-pty = "0.9.0"

--- a/krustty/src/grid.rs
+++ b/krustty/src/grid.rs
@@ -1,0 +1,136 @@
+use bitflags::bitflags;
+use std::collections::VecDeque;
+
+/// Represents the different ways a color can be defined in the terminal
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum Color {
+    /// The default foreground/background color specified by the user's theme.
+    #[default]
+    Default,
+    /// Standard 16 ANSI colors (e.g., Black, Red, Green, etc.).
+    #[expect(unused)]
+    Named(u8),
+    /// 256-color palette (xterm).
+    #[expect(unused)]
+    Indexed(u8),
+    /// 24-bit True Color (RGB).
+    #[expect(unused)]
+    Rgb { r: u8, g: u8, b: u8 },
+}
+
+bitflags! {
+    /// Text styling attributes
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct CellFlags: u16 {
+        const NONE          = 0;
+        const BOLD          = 1 << 0;
+        const DIM           = 1 << 1;
+        const ITALIC        = 1 << 2;
+        const UNDERLINE     = 1 << 3;
+        const BLINK         = 1 << 4;
+        const INVERSE       = 1 << 5;
+        const HIDDEN        = 1 << 6;
+        const STRIKETHROUGH = 1 << 7;
+    }
+}
+
+/// A single character cell on the terminal grid.
+/// Memory footprint is kept as small as possible since we will have thousands of these.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Cell {
+    c: char,
+    fg: Color,
+    bg: Color,
+    flags: CellFlags,
+}
+
+impl Default for Cell {
+    fn default() -> Self {
+        Cell {
+            c: ' ', // Empty space by default
+            fg: Color::Default,
+            bg: Color::Default,
+            flags: CellFlags::NONE,
+        }
+    }
+}
+
+/// Represents a single horizontal line of text.
+#[derive(Clone, Debug)]
+pub struct Row {
+    cells: Vec<Cell>,
+    /// Indicates if this row wraps onto the next line (useful for window resizing).
+    #[expect(unused)]
+    is_wrapped: bool,
+}
+
+impl Row {
+    pub fn new(columns: usize) -> Self {
+        Row {
+            cells: vec![Cell::default(); columns],
+            is_wrapped: false,
+        }
+    }
+}
+
+/// Main terminal Grid
+#[derive(Debug)]
+pub struct Grid {
+    /// All rows including active viewport, scrollback, and scrollahead
+    rows: VecDeque<Row>,
+    /// Maximum number of rows to store before they get dropped
+    #[expect(unused)]
+    max_rows: usize,
+    /// Current number of columns
+    width: usize,
+    /// Current number of rows in the active viewport
+    height: usize,
+    /// Current offset into history from which viewport starts
+    view_offset: usize,
+    /// The offset into the grid where the cursor currently is
+    cursor: (usize, usize),
+}
+
+impl Grid {
+    pub fn new(width: usize, height: usize, max_rows: usize) -> Self {
+        let mut rows = VecDeque::<Row>::with_capacity(max_rows);
+        for _ in 0..height {
+            rows.push_front(Row::new(width));
+        }
+
+        Grid {
+            rows,
+            max_rows,
+            width,
+            height,
+            view_offset: 0,
+            cursor: (0, 0),
+        }
+    }
+
+    #[expect(unused)]
+    pub fn scroll_up(&mut self) {
+        if self.rows.len() - self.height > self.view_offset {
+            self.view_offset += 1;
+        }
+    }
+
+    #[expect(unused)]
+    pub fn scroll_down(&mut self) {
+        self.view_offset = self.view_offset.saturating_sub(1);
+    }
+
+    pub fn write_at_cursor(&mut self, c: char) {
+        self.rows[self.cursor.0].cells[self.cursor.1].c = c;
+        self.advance_cursor();
+    }
+
+    fn advance_cursor(&mut self) {
+        if self.cursor.1 < self.width - 1 {
+            self.cursor.1 += 1;
+        } else {
+            self.rows.push_front(Row::new(self.width));
+            self.cursor.1 = 0;
+        }
+    }
+}

--- a/krustty/src/main.rs
+++ b/krustty/src/main.rs
@@ -1,13 +1,14 @@
 use rtrb::CopyToUninit;
 use winit::event_loop::EventLoop;
 
+mod grid;
+mod terminal;
 mod ui;
 
 use crate::{terminal::Terminal, ui::Application};
 
 const MAX_LINE_LENGTH: usize = 4096;
 
-mod terminal;
 fn main() -> anyhow::Result<()> {
     env_logger::init();
     let mut term = Terminal::spawn("zsh")?;

--- a/krustty/src/terminal.rs
+++ b/krustty/src/terminal.rs
@@ -3,6 +3,7 @@ use std::{
     thread::{self, JoinHandle},
 };
 
+use crate::grid::Grid;
 use portable_pty::{Child, CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use rtrb::{Consumer, Producer, RingBuffer};
 
@@ -29,7 +30,7 @@ impl Terminal {
         let std_out = pty.master.try_clone_reader()?;
         let (writer, reader) = RingBuffer::<u8>::new(4096);
         Ok(Self {
-            _pty_reader: thread::spawn(move || read_pty(std_out)),
+            _pty_reader: thread::spawn(move || read_pty(std_out, Grid::new(120, 24, 1000))),
             _pty_writer: thread::spawn(move || write_pty(std_in, reader)),
             child,
             input: writer,
@@ -61,13 +62,16 @@ pub fn write_pty(
     }
 }
 
-pub fn read_pty(mut std_out: Box<dyn Read + Send>) {
+pub fn read_pty(mut std_out: Box<dyn Read + Send>, mut grid: Grid) {
     let mut buffer = [0u8; 1024];
     loop {
         match std_out.read(&mut buffer) {
             Ok(0) => break, // EOF
             Ok(n) => {
                 let output = String::from_utf8_lossy(&buffer[..n]);
+                for c in output.chars() {
+                    grid.write_at_cursor(c);
+                }
                 print!("{}", output); // Print to stdout for visibility.
             }
             Err(e) => {


### PR DESCRIPTION
Starting point for tracking grid contents. The pty reader writes characters into the grid. Grid is not rendered to screen yet, cannot handle any ANSI VT sequences just basic printable characters.