### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,7 +989,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "krustty"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",

--- a/krustty/CHANGELOG.md
+++ b/krustty/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/wdjcodes/krustty/compare/v0.1.0...v0.1.1) - 2026-05-01
+
+### Added
+
+- handle scroll events and render scrollback buffer
+- load character glyph on cache miss
+
+### Fixed
+
+- render cursor relative to viewport
+- align glyphs when rasterizing to atlas
+
+### Other
+
+- render pipeline organized to support multiple passes
+- application owns glyph cache and atlas texture
+- create a single reference to the gpu for the application
+
 ## [0.1.0](https://github.com/wdjcodes/krustty/compare/v0.0.0...v0.1.0) - 2026-04-15
 
 ### Added

--- a/krustty/Cargo.toml
+++ b/krustty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krustty"
-version = "0.1.0"
+version = "0.1.1"
 description = "Rust based terminal emulator"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `krustty`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/wdjcodes/krustty/compare/v0.1.0...v0.1.1) - 2026-05-01

### Added

- handle scroll events and render scrollback buffer
- load character glyph on cache miss

### Fixed

- render cursor relative to viewport
- align glyphs when rasterizing to atlas

### Other

- render pipeline organized to support multiple passes
- application owns glyph cache and atlas texture
- create a single reference to the gpu for the application
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).