### PR TITLE
chore: release v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,7 +755,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "krustty"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",

--- a/krustty/CHANGELOG.md
+++ b/krustty/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/wdjcodes/krustty/compare/v0.1.1...v0.1.2) - 2026-05-09
+
+### Added
+
+- add support for inverse color mode
+- replace print with tracing library
+
+### Fixed
+
+- replace fontconfig provider to use native library
+
+### Other
+
+- change default theme to look like breeze
+- use functionality in fontconfig-v0.10.2, add log facade
+- use palette crate for color management
+
 ## [0.1.1](https://github.com/wdjcodes/krustty/compare/v0.1.0...v0.1.1) - 2026-05-01
 
 ### Added

--- a/krustty/Cargo.toml
+++ b/krustty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krustty"
-version = "0.1.1"
+version = "0.1.2"
 description = "Rust based terminal emulator"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `krustty`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/wdjcodes/krustty/compare/v0.1.1...v0.1.2) - 2026-05-09

### Added

- add support for inverse color mode
- replace print with tracing library

### Fixed

- replace fontconfig provider to use native library

### Other

- change default theme to look like breeze
- use functionality in fontconfig-v0.10.2, add log facade
- use palette crate for color management
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).