### PR TITLE
chore(ci): install libfontconfig in ci container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           shared-key: "ci-cache"
 
+      - name: Install Dependencies
+        run: sudo apt-get -y install libfontconfig1-dev
+
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
@@ -59,6 +62,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "ci-cache"
+
+      - name: Install Dependencies
+        run: sudo apt-get -y install libfontconfig1-dev
 
       - name: Run tests
         run: cargo test --all-targets --all-features


### PR DESCRIPTION
Need to install libfontconfig in ci container since krustty now uses fontconfig-sys.