### PR TITLE
chore: release v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,7 +755,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "krustty"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",

--- a/krustty/CHANGELOG.md
+++ b/krustty/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/wdjcodes/krustty/compare/v0.1.2...v0.1.3) - 2026-08-21
+
+### Added
+
+- add sgr parsing for 256 and true color
+- add support for CUP/HVP escape sequences
+- handle full screen clear (ESC[2J)
+- add support for esc[c primary device attribute request
+
+### Fixed
+
+- move esc sequences out of execute into esc_dispatch ([#47](https://github.com/wdjcodes/krustty/pull/47))
+- resolve bugs when at top and bottom rows
+- clear screen behaves as expected by ansi standards
+- reverse direction of grid to match standard coordinate system
+
+### Other
+
+- improve color support for 256 and true color ([#48](https://github.com/wdjcodes/krustty/pull/48))
+- re-orient grid and cursor to be consistent with ansi term
+
 ## [0.1.2](https://github.com/wdjcodes/krustty/compare/v0.1.1...v0.1.2) - 2026-05-09
 
 ### Added

--- a/krustty/Cargo.toml
+++ b/krustty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krustty"
-version = "0.1.2"
+version = "0.1.3"
 description = "Rust based terminal emulator"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `krustty`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/wdjcodes/krustty/compare/v0.1.2...v0.1.3) - 2026-08-21

### Added

- add sgr parsing for 256 and true color
- add support for CUP/HVP escape sequences
- handle full screen clear (ESC[2J)
- add support for esc[c primary device attribute request

### Fixed

- move esc sequences out of execute into esc_dispatch ([#47](https://github.com/wdjcodes/krustty/pull/47))
- resolve bugs when at top and bottom rows
- clear screen behaves as expected by ansi standards
- reverse direction of grid to match standard coordinate system

### Other

- improve color support for 256 and true color ([#48](https://github.com/wdjcodes/krustty/pull/48))
- re-orient grid and cursor to be consistent with ansi term
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).